### PR TITLE
feat: Allow skipping config check when installing NGINX from an OS repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ FEATURES:
 
 - Add support for installing NGINX Open Source and NGINX Plus on Alpine Linux 3.21.
 - Add a parameter, `nginx_distribution_package`, to override the default NGINX package name when installing NGINX from your distribution/OS repository.
+- Add a parameter, `nginx_skip_os_install_config_check`, to turn off the NGINX config check handler when installing NGINX from the respective distribution package manager. This should help avoid potential issues where the default NGINX config that ships with a distribution is broken for some reason.
 
 BUG FIXES:
 

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -71,6 +71,9 @@ nginx_static_modules: [http_ssl_module]
 
 # (Optional) Specify NGINX package name when installing nginx from an 'os_repository'.
 # nginx_distribution_package: @nginx:1.24/common
+# (Optional) Skip checking the NGINX configuration file after installation when installing NGINX from your OS repository.
+# Not recommended unless you know what you're doing.
+# nginx_skip_os_install_config_check: false
 
 # (Optional) Choose where to fetch the NGINX signing key from.
 # Default is the official NGINX signing key host.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,7 +23,7 @@
   ignore_errors: true
   check_mode: false
   changed_when: false
-  when: nginx_state != 'absent'
+  when: nginx_state != 'absent' or (nginx_install_from == 'os_repository' and nginx_skip_os_install_config_check | bool)
   listen: (Handler) Run NGINX
 
 - name: (Handler) Print NGINX error if syntax check fails


### PR DESCRIPTION
### Proposed changes

Add a parameter, `nginx_skip_os_install_config_check`, to turn off the NGINX config check handler when installing NGINX from the respective distribution package manager. This should help avoid potential issues where the default NGINX config that ships with a distribution is broken for some reason. Resolves #888

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
